### PR TITLE
Remove all references to `he`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanitize-markdown",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "description": "Lean and configurable allowlist-oriented HTML sanitizer",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,15 +13,11 @@
   },
   "homepage": "https://github.com/JoshuaKGoldberg/sanitize-markdown",
   "main": "sanitize-markdown.js",
-  "browser": {
-    "he": "./she.js"
-  },
   "scripts": {
     "test": "tape test/**/*.js"
   },
   "dependencies": {
-    "assignment": "2.0.0",
-    "he": "0.5.0"
+    "assignment": "2.0.0"
   },
   "devDependencies": {
     "sinon": "1.17.5",

--- a/parser.js
+++ b/parser.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var he = require('he');
+var she = require('./she');
 var lowercase = require('./lowercase');
 var attributes = require('./attributes');
 var elements = require('./elements');
@@ -107,7 +107,7 @@ function parser (html, handler) {
       if (doubleQuotedValue === void 0 && singleQuotedValue === void 0 && unquotedValue === void 0) {
         attrs[name] = void 0; // attribute is like <button disabled></button>
       } else {
-        attrs[name] = he.decode(doubleQuotedValue || singleQuotedValue || unquotedValue || '');
+        attrs[name] = she.decode(doubleQuotedValue || singleQuotedValue || unquotedValue || '');
       }
     }
   }

--- a/sanitize-markdown.js
+++ b/sanitize-markdown.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var he = require('he');
+var she = require('./she');
 var assign = require('assignment');
 var parser = require('./parser');
 var sanitizer = require('./sanitizer');

--- a/sanitizer.js
+++ b/sanitizer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var he = require('he');
+var she = require('./she');
 var lowercase = require('./lowercase');
 var attributes = require('./attributes');
 var elements = require('./elements');
@@ -60,7 +60,7 @@ function sanitizer (buffer, options) {
         out(key);
         if (typeof value === 'string') {
           out('="');
-          out(he.encode(value));
+          out(she.encode(value));
           out('"');
         }
       }

--- a/test/sanitize-markdown.js
+++ b/test/sanitize-markdown.js
@@ -62,7 +62,7 @@ test('only returns tags in the allowlist even if disallowed tag is nested', func
 });
 
 test('allows blank attribute', function (t) {
-  t.equal(insane('<div class>foo</div>', { allowedTags: ['div'] }, true), '<div>foo</div>');
+  t.equal(sanitizeMarkdown('<div class>foo</div>', { allowedTags: ['div'] }, true), '<div>foo</div>');
   t.end();
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -119,11 +119,6 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-he@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/he/-/he-0.5.0.tgz#2c05ffaef90b68e860f3fd2b54ef580989277ee2"
-  integrity sha1-LAX/rvkLaOhg8/0rVO9YCYknfuI=
-
 inherits@2, inherits@^2.0.3, inherits@~2.0.1:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"


### PR DESCRIPTION
## Overview
Swapping this library to rely only on the local `she` file instead of using `he` for SSR cases. This should have no functional implications, as we were already relying on the `she` file for browser rendering. This change allows us to use Code Sandbox for Gamut more effectively.

## Checklist
[x] I have tested this change

## Testing Instructions
1. Link this package locally to the monolith (e.g. `ln -s ~/path/to/sanitize-markdown ~/path/to/monolith/node_modules`; make sure you delete the existing `sanitize-markdown` folder first!)
2. Go to http://localhost:3000/articles/accessibility-and-html and verify the article renders appropriately with no errors
3. Go to http://localhost:3000/paths/front-end-engineer-career-path/tracks/fecp-making-a-website-accessible/modules/fecp-learn-web-accessibility/articles/what-is-digital-accessibility and verify the article renders appropriately with no errors
4. Go to any lesson and verify the narrative pane renders appropriately with no errors